### PR TITLE
Fix apparently error-y partial

### DIFF
--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -17,10 +17,10 @@ By default, the attribute is rendered as an image tag.
 <% if field.attached? %>
   <% if field.many? %>
     <% field.attachments.each do |attachment| %>
-      <%= render :partial => 'item', :field => field, :attachment => attachment %>
+      <%= render :partial => 'fields/active_storage/item', locals: { field: field, attachment: attachment } %>
       <br/>
     <% end %>
   <% else %>
-    <%= render :partial => 'item', :field => field, :attachment => field.data %>
+    <%= render :partial => 'fields/active_storage/item', locals: { field: field, attachment: field.data } %>
   <% end %>
 <% end %>


### PR DESCRIPTION
I was trying to preview an image file in a resource index view, and was hitting two errors:

First, the `_item.html.erb` partial wasn't being found, and secondly, the `field` and `attachment` locals weren't available. Looking at the source code, it seems like this is a simple syntax issue in ` app/views/fields/active_storage/_index.html.erb`, particularly since when fixed, that file becomes identical to  `app/views/fields/active_storage/_show.html.erb`.

My supposition is that this is simply a typo that hasn't been fixed, so I'm submitting a PR to fix it. If I'm missing something and it's deliberate, feel free to ignore me!