### PR TITLE
don't autoplay audio on show pages

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -5,7 +5,7 @@
 <% elsif attachment.video? and !field.url_only? %>
   <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
 <% elsif attachment.audio? and !field.url_only? %>
-  <%= audio_tag(field.url(attachment), autoplay: true, controls: true) %>
+  <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
 <% elsif attachment.previewable? and !field.url_only? %>
   <%= image_tag(field.preview(attachment, resize: "595x842>")) %>
   <br/>


### PR DESCRIPTION
I turned off autoplay because I'd like to browse my admin without hearing audio. It was especially frustrating on a model with multiple audio files attached to one record - they all start autoplaying at the same time, overlapping each other.