### PR TITLE
fix(show in index): show_in_index? always return true

### DIFF
--- a/example-project/Gemfile.lock
+++ b/example-project/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    administrate-field-active_storage (0.1.6)
+    administrate-field-active_storage (0.1.7)
       administrate (>= 0.2.0.rc1)
       rails (>= 5.2)
 

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -16,7 +16,7 @@ module Administrate
       end
 
       def show_in_index?
-        options.key?(:destroy_path)
+        options.fetch(:show_in_index, false)
       end
 
       def show_preview_size


### PR DESCRIPTION
`show_in_index?` always return true if destroy path is set causing unexpected behaviour

This is caused by a bug in the active storage field model that check the key of `destroy_path` instead of the `show_in_index`.

Fixed by fetching `show_in_index` options instead and set the default to false.