### PR TITLE
Prevent items rendering with nil field data

### DIFF
--- a/app/views/fields/active_storage/_form.html.erb
+++ b/app/views/fields/active_storage/_form.html.erb
@@ -20,7 +20,7 @@ By default, the input is a text field for the image's URL.
 </div>
 
 <div class="field-unit__field">
-  <% if field.attached? %>
+  <% if field.data.present? && field.attached? %>
     <%= render partial: 'fields/active_storage/items', locals: { field: field, removable: field.destroyable? } %>
     <br />
     Add:

--- a/contribute.md
+++ b/contribute.md
@@ -7,3 +7,4 @@
 - Peter Bhat Harkins [@pushcx](https://github.com/pushcx)
 - Delta Purna Widyangga [@deltapurna](https://github.com/deltapurna)
 - Joé Dupuis [@twistedjoe](https://github.com/twistedjoe)
+- Eugeny Khlopin [@evgeniy-khlopin](https://github.com/evgeniy-khlopin)


### PR DESCRIPTION
Adds compatibility with the [nested_has_many gem](https://github.com/nickcharlton/administrate-field-nested_has_many) which renders fields with nil data.
Fixes #13 