### PR TITLE
Change resize option to conform with rails 6

### DIFF
--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -24,7 +24,7 @@ By default, the attribute is rendered as an image tag.
 %>
 <% if field.attached? %>
   <% if field.show_in_index? %>
-    <%= render partial: 'fields/active_storage/item', locals: { field: field, attachment: attachments[0], image_size: "250x250>" } %>
+    <%= render partial: 'fields/active_storage/item', locals: { field: field, attachment: attachments[0], image_size: [250, 250] } %>
   <% end %>
   <%= pluralize(attachments.count, 'Attached file') %>
 <% else %>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -24,19 +24,19 @@ controlled via a boolean local variable.
 <%
   # By default we don't allow attachment removal
   removable = local_assigns.fetch(:removable, false)
-  image_size = local_assigns.fetch(:image_size, "1920x1080>")
+  image_size = local_assigns.fetch(:image_size, [1920, 1080])
 %>
 
 <% if attachment.image? and !field.url_only? %>
-  <%= image_tag(field.variant(attachment, resize: image_size)) %>
+  <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
 <% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
-  <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
+  <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
 <% elsif attachment.video? and !field.url_only? %>
   <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
 <% elsif attachment.audio? and !field.url_only? %>
   <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
 <% elsif attachment.previewable? and !field.url_only? %>
-  <%= image_tag(field.preview(attachment, resize: "595x842>")) %>
+  <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
   <br/>
   Download: <%= link_to(attachment.filename, field.blob_url(attachment)) %>
 <% else %>

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -20,7 +20,7 @@ module Administrate
       end
 
       def show_preview_size
-        options.fetch(:show_preview_size, "1080x1920>")
+        options.fetch(:show_preview_size, [1080, 1920])
       end
 
       def many?


### PR DESCRIPTION
When using this gem rails was warning for 

> DEPRECATION WARNING: Active Storage's ImageProcessing transformer doesn't support :combine_options, as it always generates a single ImageMagick command. Passing :combine_options will not be supported in Rails 6.1.

This PR fixes that by using the new resize option of Array instead of String as per [Rails Guides](https://guides.rubyonrails.org/v6.0/active_storage_overview.html#transforming-images)