### PR TITLE
Update readme of n+1

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,8 @@ In order to prevent N+1 queries from active storage you have to modify your admi
 ```ruby
 module Admin
   class UsersController < Admin::ApplicationController
-    def index
-      super
-      @resources = User.with_attached_avatars.
-        page(params[:page]).
-        per(10)
+    def scoped_resource
+      resource_class.with_attached_avatars
     end
   end
 end


### PR DESCRIPTION
Update the [Prevent N+1 queries](https://github.com/Dreamersoul/administrate-field-active_storage#prevent-n1-queries) of the readme.

Overloading `scoped_resouce` looks better than overloading `index` action.

Actually the `index` action is doing more than just paging:

https://github.com/thoughtbot/administrate/blob/95b0153dd523af55c47df32b0a28ca4d1bb11fa6/app/controllers/administrate/application_controller.rb#L5