### PR TITLE
Link to download attachment + hide count if 0 or 1

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -27,19 +27,23 @@ controlled via a boolean local variable.
   image_size = local_assigns.fetch(:image_size, [1920, 1080])
 %>
 
-<%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-  <% if attachment.image? and !field.url_only? %>
+<% if attachment.image? and !field.url_only? %>
+  <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
     <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
-  <% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
-    <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-  <% elsif attachment.video? and !field.url_only? %>
-    <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-  <% elsif attachment.audio? and !field.url_only? %>
-    <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
-  <% elsif attachment.previewable? and !field.url_only? %>
-    <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
-  <% else %>
-    <%= attachment.filename %>
+  <% end %>
+<% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
+  <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
+<% elsif attachment.video? and !field.url_only? %>
+  <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
+<% elsif attachment.audio? and !field.url_only? %>
+  <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
+<% else %>
+  <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
+    <% if attachment.previewable? and !field.url_only? %>
+      <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
+    <% else %>
+      <%= attachment.filename %>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -27,20 +27,20 @@ controlled via a boolean local variable.
   image_size = local_assigns.fetch(:image_size, [1920, 1080])
 %>
 
-<% if attachment.image? and !field.url_only? %>
-  <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
-<% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
-  <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-<% elsif attachment.video? and !field.url_only? %>
-  <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-<% elsif attachment.audio? and !field.url_only? %>
-  <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
-<% elsif attachment.previewable? and !field.url_only? %>
-  <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
-  <br/>
-  Download: <%= link_to(attachment.filename, field.blob_url(attachment)) %>
-<% else %>
-  <%= link_to(attachment.filename, field.blob_url(attachment)) %>
+<%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
+  <% if attachment.image? and !field.url_only? %>
+    <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
+  <% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
+    <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
+  <% elsif attachment.video? and !field.url_only? %>
+    <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
+  <% elsif attachment.audio? and !field.url_only? %>
+    <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
+  <% elsif attachment.previewable? and !field.url_only? %>
+    <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
+  <% else %>
+    <%= attachment.filename %>
+  <% end %>
 <% end %>
 
 <% if removable %>


### PR DESCRIPTION
- downlolad original attachment by clicking on it
- only show the number of attachments if greater than 1; show `-` if 0
- show filename in tooltip text

index (with tooltip on mouse hover):
<img width="276" alt="Screenshot 2020-02-26 at 11 40 40" src="https://user-images.githubusercontent.com/4217871/75337219-dcb90480-588c-11ea-91aa-3bdd514da74c.png">

show (with tooltip on mouse hover):
<img width="971" alt="Screenshot 2020-02-26 at 11 40 53" src="https://user-images.githubusercontent.com/4217871/75337231-e2aee580-588c-11ea-9be1-7d1e30457b20.png">

Fixes #29