### PR TITLE
Support previews for images that ImageMagick doesn't support

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -27,8 +27,10 @@ controlled via a boolean local variable.
   image_size = local_assigns.fetch(:image_size, [1920, 1080])
 %>
 
-<% if attachment.image? and !field.url_only? %>
+<% if attachment.image? and attachment.variable? and !field.url_only? %>
   <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
+<% elsif attachment.image? and !field.url_only?
+  <%= image_tag(field.url(attachment)) %>
 <% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
   <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
 <% elsif attachment.video? and !field.url_only? %>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -29,7 +29,7 @@ controlled via a boolean local variable.
 
 <% if attachment.image? and attachment.variable? and !field.url_only? %>
   <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
-<% elsif attachment.image? and !field.url_only?
+<% elsif attachment.image? and !field.url_only? %>
   <%= image_tag(field.url(attachment)) %>
 <% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
   <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>

--- a/contribute.md
+++ b/contribute.md
@@ -9,4 +9,4 @@
 - Joé Dupuis [@twistedjoe](https://github.com/twistedjoe)
 - Eugeny Khlopin [@evgeniy-khlopin](https://github.com/evgeniy-khlopin)
 - Daniel Tinoco [@0urobor0s](https://github.com/0urobor0s)
-- Matthew [@nhui](https://github.com/mhui)
+- Matthew Hui [@mhui](https://github.com/mhui)

--- a/contribute.md
+++ b/contribute.md
@@ -9,3 +9,4 @@
 - Joé Dupuis [@twistedjoe](https://github.com/twistedjoe)
 - Eugeny Khlopin [@evgeniy-khlopin](https://github.com/evgeniy-khlopin)
 - Daniel Tinoco [@0urobor0s](https://github.com/0urobor0s)
+- Matthew [@nhui](https://github.com/mhui)


### PR DESCRIPTION
I uploaded a GIF that's in webp format. ActiveStorage treats it as an image but I can preview it due to https://edgeapi.rubyonrails.org/classes/ActiveStorage/InvariableError.html