### PR TITLE
Destroy action improvements

### DIFF
--- a/app/views/fields/active_storage/_form.html.erb
+++ b/app/views/fields/active_storage/_form.html.erb
@@ -21,7 +21,7 @@ By default, the input is a text field for the image's URL.
 
 <div class="field-unit__field">
   <% if field.attached? %>
-    <%= render partial: 'fields/active_storage/items', locals: { field: field, removable: field.destroyable? } %>
+    <%= render partial: 'fields/active_storage/items', locals: { field: field } %>
   <% end %>
 
   <div>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -24,11 +24,6 @@ controlled via a boolean local variable.
   Maximum size of the ActiveStorage preview.
 %>
 
-<%
-  # By default we don't allow attachment removal
-  removable = local_assigns.fetch(:removable, false)
-%>
-
 <div>
   <%= render partial: 'fields/active_storage/preview', locals: local_assigns %>
 </div>
@@ -37,7 +32,10 @@ controlled via a boolean local variable.
   <%= link_to 'Download', field.blob_url(attachment), title: attachment.filename %>
 </div>
 
-<% if removable %>
-  <%= link_to 'Remove', field.destroy_path(field, attachment), method: :delete, class: 'remove-attachment-link' %>
+<% if field.destroy_url.present? %>
+  <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
+  <div>
+    <%= link_to 'Remove', destroy_url, method: :delete, class: 'remove-attachment-link' %>
+  </div>
   <hr>
 <% end %>

--- a/example-project/app/controllers/admin/users_controller.rb
+++ b/example-project/app/controllers/admin/users_controller.rb
@@ -17,5 +17,11 @@ module Admin
 
     # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
     # for more information
+
+    def destroy_avatar
+      avatar = requested_resource.avatars.find(params[:attachment_id])
+      avatar.purge
+      redirect_back(fallback_location: requested_resource)
+    end
   end
 end

--- a/example-project/app/controllers/users_controller.rb
+++ b/example-project/app/controllers/users_controller.rb
@@ -1,7 +1,7 @@
 class UsersController < ApplicationController
-    def remove_attachment
-        attachment = ActiveStorage::Attachment.find(params[:attachment_id])
-        attachment.purge
-        redirect_back(fallback_location: "/")
+    def destroy_avatar
+        avatar = requested_resource.avatars.find(params[:attachment_id])
+        avatar.purge
+        redirect_back(fallback_location: requested_resource)
     end
 end

--- a/example-project/app/dashboards/user_dashboard.rb
+++ b/example-project/app/dashboards/user_dashboard.rb
@@ -10,7 +10,9 @@ class UserDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
     id: Field::Number,
     name: Field::String,
-    avatars: Field::ActiveStorage.with_options({:destroy_path => :custom_active_record_remove_path, :show_in_index => true}),
+    avatars: Field::ActiveStorage.with_options(
+      show_in_index: true
+    ),
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze

--- a/example-project/config/routes.rb
+++ b/example-project/config/routes.rb
@@ -1,9 +1,10 @@
 Rails.application.routes.draw do
   namespace :admin do
-    resources :users
+    resources :users do
+      delete :avatar, on: :member, action: :destroy_avatar
+    end
 
     root to: "users#index"
   end
-  delete "custom_active_record_remove", to: 'users#remove_avatar'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
- removes the need to explicitly configure the field when defining the destroy route in a standard manner
- this convention can be overridden/customized with more flexibility by giving access to the Administrate `namespace`, `record` and `attachment` objects
- cleans up the code related to the attachment destroy action
- I also took the opportunity to improve the definition of `many?`

NB: The PR currently has a caveat, an error is thrown if the expected route is not defined whereas instead, it would be preferable to just disable the button. That is because in the definition of `destroy_url` I don't know how to check whether the route exists (as it is written in a general way without using a named route).