### PR TITLE
Attachment display tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,53 +95,53 @@ Your `routes.rb` file must point to a controller action with method `delete` whi
   end
 ```
 
-### url_only
-Only the following needs to change in order for the field to be url_only
-```ruby
+## Options
+
+Various options can be passed to `Administrate::Field::ActiveStorage#with_options`
+as illustrated below:
+
+```rb
 class ModelDashboard < Administrate::BaseDashboard
   ATTRIBUTE_TYPES = {
-    attachments: Field::ActiveStorage.with_options({url_only: true}),
+    attachments: Field::ActiveStorage.with_options(index_display_preview: false),
     # ...
   }
   # ...
 end
 ```
 
-### show_in_index
-This will preview thumbnails in the index page and if you're using `has_many` it will show the first one as a thumbnail and a count of the total attached files
-```ruby
-class ModelDashboard < Administrate::BaseDashboard
-  ATTRIBUTE_TYPES = {
-    attachments: Field::ActiveStorage.with_options({show_in_index: true}),
-    # ...
-  }
-  # ...
-end
-```
+### show_display_preview
 
-### show_preview_size
-Supply the size of the image preview inside the show page.  Check out the [mini_magic#resize_to_limit](https://github.com/janko/image_processing/blob/master/doc/minimagick.md#methods) documentation
-```ruby
-class ModelDashboard < Administrate::BaseDashboard
-  ATTRIBUTE_TYPES = {
-    attachments: Field::ActiveStorage.with_options({show_preview_size:  [150, 200]}),
-    # ...
-  }
-  # ...
-end
-```
+Display attachment preview.
+
+Defaults to `true`.
+
+### index_display_preview
+
+Displays the first attachment (which is the only attachment in case of `has_one`)
+in the `index` action.
+
+Defaults to `true`.
+
+### index_preview_size and show_preview_size
+
+Indicate the size of the image preview for the `index` and `show` actions, respectively.
+Refer to [mini_magic#resize_to_limit](https://github.com/janko/image_processing/blob/master/doc/minimagick.md#methods)
+for documentation.
+
+Default to `[150, 150]` and `[800, 800]`, respectively.
+
+### index_display_count
+
+Displays the number of attachments in the `index` action.
+
+Defaults to `true` if number of attachments is not 1.
 
 ### direct_upload
-If you want to upload directly from the browser to the cloud you can use direct_upload
-```ruby
-class ModelDashboard < Administrate::BaseDashboard
-  ATTRIBUTE_TYPES = {
-    attachments: Field::ActiveStorage.with_options({direct_upload: true}),
-    # ...
-  }
-  # ...
-end
-```
+
+Enables direct upload from the browser to the cloud.
+
+Defaults to `false`.
 
 Don't forget to include [ActiveStorage JavaScript](https://edgeguides.rubyonrails.org/active_storage_overview.html#direct-uploads). You can use `rails generate administrate:assets:javascripts` to be able to customize Administrate JavaScripts in your application.
 

--- a/app/views/fields/active_storage/_form.html.erb
+++ b/app/views/fields/active_storage/_form.html.erb
@@ -20,11 +20,12 @@ By default, the input is a text field for the image's URL.
 </div>
 
 <div class="field-unit__field">
-  <% if field.data.present? && field.attached? %>
+  <% if field.attached? %>
     <%= render partial: 'fields/active_storage/items', locals: { field: field, removable: field.destroyable? } %>
-    <br />
-    Add:
   <% end %>
 
-  <%= f.file_field field.attribute, multiple: field.many?, direct_upload: field.direct? %>
+  <div>
+    <%= field.can_add_attachment? ? "Add:" : "Replace:" %>
+    <%= f.file_field field.attribute, multiple: field.many?, direct_upload: field.direct? %>
+  </div>
 </div>

--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -14,19 +14,25 @@ By default, the attribute is rendered as an image tag.
 
 [1]: http://www.rubydoc.info/gems/administrate/Administrate/Field/Image
 %>
-<style> <%# figure out a way to remove this %>
-  td img {
-      max-height: unset !important;
-  }
-</style>
-<% 
-  attachments = Array(field.many? ? field.attachments : field.data)
-%>
+
 <% if field.attached? %>
-  <% if field.show_in_index? %>
-    <%= render partial: 'fields/active_storage/item', locals: { field: field, attachment: attachments[0], image_size: [250, 250] } %>
+  <style> <%# figure out a way to remove this %>
+  td img {
+    max-height: unset !important;
+  }
+  </style>
+  <% if field.index_display_preview? %>
+    <%= render partial: 'fields/active_storage/item',
+               locals: {
+                   field: field,
+                   attachment: field.attachments[0],
+                   size: field.index_preview_size
+               } %>
   <% end %>
-  <%= pluralize(attachments.count, 'Attached file') %>
-<% else %>
-0 Attached files
+
+  <% if field.index_display_count? %>
+    <div class="attachments-count">
+      <%= pluralize(field.attachments.count, 'Attachment') %>
+    </div>
+  <% end %>
 <% end %>

--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -22,7 +22,7 @@ By default, the attribute is rendered as an image tag.
   }
   </style>
   <% if field.index_display_preview? %>
-    <%= render partial: 'fields/active_storage/item',
+    <%= render partial: 'fields/active_storage/preview',
                locals: {
                    field: field,
                    attachment: field.attachments[0],

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -19,39 +19,47 @@ controlled via a boolean local variable.
 - `removable`:
   A boolean used to control the display of a `Remove` link which
   is used to destroy a single attachment.  Defaults to `false`
+- `size`:
+  [x, y]
+  Maximum size of the ActiveStorage preview.
 %>
 
 <%
   # By default we don't allow attachment removal
   removable = local_assigns.fetch(:removable, false)
-  image_size = local_assigns.fetch(:image_size, [1920, 1080])
 %>
 
-<% if attachment.image? and attachment.variable? and !field.url_only? %>
-  <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-    <%= image_tag(field.variant(attachment, resize_to_limit: image_size)) %>
-  <% end %>
-<% elsif attachment.image? and !field.url_only? %>
-  <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-    <%= image_tag(field.url(attachment)) %>
-  <% end %>
-<% elsif attachment.video? and attachment.previewable? and !field.url_only? %> <%# if ffmpeg is installed %>
-  <%= video_tag(field.url(attachment), poster: field.preview(attachment, resize_to_limit: image_size), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-<% elsif attachment.video? and !field.url_only? %>
-  <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "width: 100%; height: auto;") %>
-<% elsif attachment.audio? and !field.url_only? %>
-  <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
-<% else %>
-  <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-    <% if attachment.previewable? and !field.url_only? %>
-      <%= image_tag(field.preview(attachment, resize_to_limit: [595, 842])) %>
-    <% else %>
-      <%= attachment.filename %>
+<div style="width: <%=size[0]%>px; height: auto; overflow: hidden;">
+  <% if attachment.image? and attachment.variable? and field.show_display_preview? %>
+    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
+      <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
+    <% end %>
+  <% elsif attachment.image? and field.show_display_preview? %>
+    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
+      <%= image_tag(field.url(attachment)) %>
+    <% end %>
+  <% elsif attachment.video? and attachment.previewable? and field.show_display_preview? %>
+    <%= video_tag(field.url(attachment),
+                  poster: field.preview(attachment, resize_to_limit: size),
+                  controls: true,
+                  autobuffer: true,
+                  style: "object-fit: contain; width: 100%; height: 100%;") %>
+  <% elsif attachment.video? and field.show_display_preview? %>
+    <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: style) %>
+  <% elsif attachment.audio? and field.show_display_preview? %>
+    <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
+  <% else %>
+    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
+      <% if attachment.previewable? and field.show_display_preview? %>
+        <%= image_tag(field.preview(attachment, resize_to_limit: size)) %>
+      <% else %>
+        <%= attachment.filename %>
+      <% end %>
     <% end %>
   <% end %>
-<% end %>
 
-<% if removable %>
-  <%= link_to 'Remove', field.destroy_path(field, attachment), method: :delete, class: 'remove-attachment-link' %>
-  <hr>
-<% end %>
+  <% if removable %>
+    <%= link_to 'Remove', field.destroy_path(field, attachment), method: :delete, class: 'remove-attachment-link' %>
+    <hr>
+  <% end %>
+</div>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -29,37 +29,15 @@ controlled via a boolean local variable.
   removable = local_assigns.fetch(:removable, false)
 %>
 
-<div style="width: <%=size[0]%>px; height: auto; overflow: hidden;">
-  <% if attachment.image? and attachment.variable? and field.show_display_preview? %>
-    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-      <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
-    <% end %>
-  <% elsif attachment.image? and field.show_display_preview? %>
-    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-      <%= image_tag(field.url(attachment)) %>
-    <% end %>
-  <% elsif attachment.video? and attachment.previewable? and field.show_display_preview? %>
-    <%= video_tag(field.url(attachment),
-                  poster: field.preview(attachment, resize_to_limit: size),
-                  controls: true,
-                  autobuffer: true,
-                  style: "object-fit: contain; width: 100%; height: 100%;") %>
-  <% elsif attachment.video? and field.show_display_preview? %>
-    <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: style) %>
-  <% elsif attachment.audio? and field.show_display_preview? %>
-    <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
-  <% else %>
-    <%= link_to(field.blob_url(attachment), title: attachment.filename) do %>
-      <% if attachment.previewable? and field.show_display_preview? %>
-        <%= image_tag(field.preview(attachment, resize_to_limit: size)) %>
-      <% else %>
-        <%= attachment.filename %>
-      <% end %>
-    <% end %>
-  <% end %>
-
-  <% if removable %>
-    <%= link_to 'Remove', field.destroy_path(field, attachment), method: :delete, class: 'remove-attachment-link' %>
-    <hr>
-  <% end %>
+<div>
+  <%= render partial: 'fields/active_storage/preview', locals: local_assigns %>
 </div>
+
+<div>
+  <%= link_to 'Download', field.blob_url(attachment), title: attachment.filename %>
+</div>
+
+<% if removable %>
+  <%= link_to 'Remove', field.destroy_path(field, attachment), method: :delete, class: 'remove-attachment-link' %>
+  <hr>
+<% end %>

--- a/app/views/fields/active_storage/_items.html.erb
+++ b/app/views/fields/active_storage/_items.html.erb
@@ -9,17 +9,22 @@ This partial renders one or more attachments
   An instance of [Administrate::Field::Image].
   A wrapper around the image url pulled from the database.
 - `removable`:
-  A boolean used to control the display of a `Remove` link which 
+  A boolean used to control the display of a `Remove` link which
   is used to destroy a single attachment.  Defaults to `false`
 %>
 
-<% 
-  attachments = Array(field.many? ? field.attachments : field.data)
+<%
   removable = local_assigns.fetch(:removable, false)
 %>
 
-<% attachments.each do |attachment| %>
+<% field.attachments.each do |attachment| %>
   <div class="attachments-listing">
-    <%= render partial: 'fields/active_storage/item', locals: { field: field, attachment: attachment, removable: removable, image_size: field.show_preview_size } %>
+    <%= render partial: 'fields/active_storage/item',
+               locals: {
+                   field: field,
+                   attachment: attachment,
+                   removable: removable,
+                   size: field.show_preview_size
+               } %>
   </div>
 <% end %>

--- a/app/views/fields/active_storage/_preview.html.erb
+++ b/app/views/fields/active_storage/_preview.html.erb
@@ -1,0 +1,25 @@
+<div style="width: <%=size[0]%>px; height: auto; overflow: hidden;">
+  <% if attachment.image? %>
+    <% if attachment.variable? %>
+      <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
+    <% else %>
+      <%= image_tag(field.url(attachment)) %>
+    <% end %>
+  <% elsif attachment.video? %>
+    <% if attachment.previewable? %>
+      <%= video_tag(field.url(attachment),
+                    poster: field.preview(attachment, resize_to_limit: size),
+                    controls: true,
+                    autobuffer: true,
+                    style: "object-fit: contain; width: 100%; height: 100%;") %>
+    <% else %>
+      <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: style) %>
+    <% end %>
+  <% elsif attachment.audio? %>
+    <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>
+  <% elsif attachment.previewable? %>
+    <%= image_tag(field.preview(attachment, resize_to_limit: size)) %>
+  <% else %>
+    <%= attachment.filename %>
+  <% end %>
+</div>

--- a/app/views/fields/active_storage/_show.html.erb
+++ b/app/views/fields/active_storage/_show.html.erb
@@ -17,4 +17,6 @@ By default, the attribute is rendered as an image tag.
 
 <% if field.attached? %>
   <%= render partial: 'fields/active_storage/items', locals: { field: field } %>
+<% else %>
+  No attachment
 <% end %>

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -7,20 +7,28 @@ module Administrate
       class Engine < ::Rails::Engine
       end
 
-      def url_only?
-        options.fetch(:url_only, false)
-      end
-
       def destroyable?
         options.key?(:destroy_path)
       end
 
-      def show_in_index?
-        options.fetch(:show_in_index, false)
+      def index_display_preview?
+        options.fetch(:index_display_preview, true)
+      end
+
+      def index_preview_size
+        options.fetch(:index_preview_size, [150, 150])
+      end
+
+      def index_display_count?
+        options.fetch(:index_display_count) { attachments.count != 1 }
+      end
+
+      def show_display_preview?
+        options.fetch(:show_display_preview, true)
       end
 
       def show_preview_size
-        options.fetch(:show_preview_size, [1080, 1920])
+        options.fetch(:show_preview_size, [800, 800])
       end
 
       def many?
@@ -65,7 +73,14 @@ module Administrate
         Rails.application.routes.url_helpers.send(destroy_path_helper, {:record_id => record_id, :attachment_id => attachment_id})
       end
 
-      delegate :attached?, to: :data
+      def can_add_attachment?
+        many? || attachments.empty?
+      end
+
+      def attached?
+        data.present? && data.attached?
+      end
+
       delegate :attachments, to: :data
     end
   end


### PR DESCRIPTION
Preview display:
-  `index_display_preview` replaces `show_in_index` as the term "show" can be ambiguous with the `show` action
- `show_display_preview` replaces `url_only` for coherence. This also fixes the issue that `url_only` applied to the `index` and was thus interfering with `show_in_index`.
- both values default to `true`

Preview size:
- centralizes the size defaults into the library code
- set separate default sizes `index_preview_size` and `show_preview_size` for the `index` and `show` actions, respectively
- adds more responsiveness to video attachments

Displaying number of attachments in index action (`index_display_count`):
- defaults to `true` if number of attachments is not 1

Show:
- display "No attachment" if no attachment present

Edit:
- change "Add" text to "Replace" if attachment is `has_one` and already has an attachment

DRY code:
- remove multiple calls to `field.url_only?`
- simplify calls to `field.attached?`
- remove multiple `link_to`s which were somewhat arbitrarily wrapping some preview types and not others (for instance it was not possible to download a video). Replaced by a single "Download" link (so this mostly reverts my PR #31).