### PR TITLE
Fix N+1 queries on index page

### DIFF
--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -25,7 +25,7 @@ By default, the attribute is rendered as an image tag.
     <%= render partial: 'fields/active_storage/preview',
                locals: {
                    field: field,
-                   attachment: field.attachments[0],
+                   attachment: field.data,
                    size: field.index_preview_size
                } %>
   <% end %>

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -16,7 +16,7 @@ module Administrate
       end
 
       def index_display_count?
-        options.fetch(:index_display_count) { attachments.present? && attachments.count != 1 }
+        options.fetch(:index_display_count) { attached? && attachments.count != 1 }
       end
 
       def show_display_preview?


### PR DESCRIPTION
I first noticed there were a lot of repeated queries in my logs when viewing my dashboard index displaying active storage attachment previews, in spite of using `.with_attached_XXX` in the administrate controller.

I haven't quite understood why `attachments.present?` leads to N+1 queries, and why it's not the case when querying `attachments.count`. But anyway I got it fixed by replacing `attachments.present?` with `attached?`. This was further confirmed using the [Bullet](https://github.com/flyerhzm/bullet/) library.