### PR TITLE
Add confirmation alert when deleting attachment

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -36,7 +36,7 @@ controlled via a boolean local variable.
 <% if field.destroy_url.present? %>
   <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
   <div>
-    <%= link_to 'Remove', destroy_url, method: :delete, class: 'remove-attachment-link' %>
+    <%= link_to 'Remove', destroy_url, method: :delete, class: 'remove-attachment-link', data: { confirm: t("administrate.actions.confirm") } %>
   </div>
   <hr>
 <% end %>


### PR DESCRIPTION
This prevents accidental data loss by making an alert for the user to confirm that they want to delete the attachment