### PR TITLE
Resolve variant combine_options deprecation

### DIFF
--- a/contribute.md
+++ b/contribute.md
@@ -12,3 +12,4 @@
 - Matthew Hui [@mhui](https://github.com/mhui)
 - Sébastien Dubois [@sedubois](https://github.com/sedubois)
 - Jazzy Gasper [@jazzygasper](https://github.com/jazzygasper)
+- David Ma [@taikon](https://github.com/taikon)

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -50,7 +50,7 @@ module Administrate
       end
 
       def variant(attachment, options)
-        Rails.application.routes.url_helpers.rails_representation_path(attachment.variant(combine_options: options), only_path: true)
+        Rails.application.routes.url_helpers.rails_representation_path(attachment.variant(options), only_path: true)
       end
 
       def url(attachment)


### PR DESCRIPTION
 `combine_options` for `ImageProcessingTransformer` is deprecated as of Rails 6.1. See issue #47.

This resolves the warning: "Active Storage's ImageProcessing transformer doesn't support :combine_options, as it always generates a single ImageMagick command. Passing :combine_options will not be supported in Rails 6.1".