### PR TITLE
Fix duplication bug when same blob is attached to several records

### DIFF
--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -70,7 +70,7 @@ module Administrate
       end
 
       def attachments
-        data.attachments if attached?
+        many? ? data.attachments : [data.attachment] if attached?
       end
     end
   end


### PR DESCRIPTION
If the same blob is attached to many records, the blob is shown as many times when viewing one of these records:

<img width="328" alt="Screenshot 2021-01-02 at 12 52 58" src="https://user-images.githubusercontent.com/4217871/103456763-87921e80-4cf9-11eb-9f0a-ce3a7f1c39df.png">

With this PR the image shows up a single time at it should:

<img width="343" alt="Screenshot 2021-01-02 at 12 51 55" src="https://user-images.githubusercontent.com/4217871/103456767-911b8680-4cf9-11eb-80e7-858359a377d9.png">
