### PR TITLE
fix(README): fix the sample code of specifying version for Rails 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ gem "image_processing"
 
 for rails 5.x use the following
 ```ruby
-gem 'administrate-field-active_storage' -v 0.1.8
+gem 'administrate-field-active_storage', "0.1.8"
 ```
 
 Install:


### PR DESCRIPTION
It seems that the way to specify Gem's version is wrong.

ref: https://bundler.io/gemfile.html