### PR TITLE
CSP compatibility by using only inline style tags with nonce

### DIFF
--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -16,7 +16,7 @@ By default, the attribute is rendered as an image tag.
 %>
 
 <% if field.attached? %>
-  <style> <%# figure out a way to remove this %>
+  <style type="text/css" nonce="<%= content_security_policy_nonce %>"> <%# figure out a way to remove this %>
   td img {
     max-height: unset !important;
   }

--- a/app/views/fields/active_storage/_preview.html.erb
+++ b/app/views/fields/active_storage/_preview.html.erb
@@ -1,4 +1,11 @@
-<div style="width: <%=size[0]%>px; height: auto; overflow: hidden;">
+<style type="text/css" nonce="<%= content_security_policy_nonce %>">
+  #as-field-<%= attachment.id %> {
+    width: <%=size[0]/2%>px; 
+    height: auto; 
+    overflow: hidden;
+  }
+</style>
+<div id="as-field-<%= attachment.id %>">
   <% if attachment.image? %>
     <% if attachment.variable? %>
       <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
@@ -6,14 +13,21 @@
       <%= image_tag(field.url(attachment)) %>
     <% end %>
   <% elsif attachment.video? %>
+    <style type="text/css" nonce="<%= content_security_policy_nonce %>">
+      #as-field-video-<%= attachment.id %> {
+        object-fit: contain; 
+        width: 100%; 
+        height: 100%;
+      }
+    </style>
     <% if attachment.previewable? %>
       <%= video_tag(field.url(attachment),
                     poster: field.preview(attachment, resize_to_limit: size),
                     controls: true,
                     autobuffer: true,
-                    style: "object-fit: contain; width: 100%; height: 100%;") %>
+                    id: "as-field-video-#{attachment.id}") %>
     <% else %>
-      <%= video_tag(field.url(attachment), controls: true, autobuffer: true, style: "object-fit: contain; width: 100%; height: 100%;") %>
+      <%= video_tag(field.url(attachment), controls: true, autobuffer: true, id: "as-field-video-#{attachment.id}") %>
     <% end %>
   <% elsif attachment.audio? %>
     <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>


### PR DESCRIPTION
Fixes #79 

There is no functional change, all inline styles are now inside tags where nonces are added.
Still not a pretty solution with inline styles but at least no errors when using CSP.