### PR TITLE
Add ability to use new named variants for previewing images

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ for documentation.
 
 Default to `[150, 150]` and `[800, 800]`, respectively.
 
+### index_preview_variant and show_preview_variant
+
+Use a named variant for image preview for the `index` and `show` actions, respectively.
+Named image variants were [added in Rails 7](https://guides.rubyonrails.org/v7.0/active_storage_overview.html#has-one-attached).
+When set, this takes precedence over `index_preview_size` and `show_preview_size`.
+
 ### index_display_count
 
 Displays the number of attachments in the `index` action.

--- a/app/assets/stylesheets/administrate-field-active_storage/application.css
+++ b/app/assets/stylesheets/administrate-field-active_storage/application.css
@@ -1,0 +1,15 @@
+td img {
+  max-height: unset !important;
+}
+.as-field {
+  height: auto;
+  overflow: hidden;
+}
+.as-field-index img {
+  width: 50%;
+}
+.as-field-video {
+  object-fit: contain;
+  width: 100%;
+  height: 100%;
+}

--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -16,11 +16,6 @@ By default, the attribute is rendered as an image tag.
 %>
 
 <% if field.attached? %>
-  <style type="text/css" nonce="<%= content_security_policy_nonce %>"> <%# figure out a way to remove this %>
-  td img {
-    max-height: unset !important;
-  }
-  </style>
   <% if field.index_display_preview? %>
     <% if field.many? %>
       <%= render partial: 'fields/active_storage/items',

--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -21,6 +21,7 @@ By default, the attribute is rendered as an image tag.
       <%= render partial: 'fields/active_storage/items',
                  locals: {
                      field: field,
+                     variant: field.index_preview_variant,
                      size: field.index_preview_size
                  } %>
     <% else %>
@@ -28,6 +29,7 @@ By default, the attribute is rendered as an image tag.
                  locals: {
                      field: field,
                      attachment: field.data,
+                     variant: field.index_preview_variant,
                      size: field.index_preview_size
                  } %>
     <% end %>

--- a/app/views/fields/active_storage/_items.html.erb
+++ b/app/views/fields/active_storage/_items.html.erb
@@ -19,6 +19,7 @@ This partial renders one or more attachments
 
 <%
   removable = local_assigns.fetch(:removable, false)
+  variant = local_assigns.fetch(:variant, field.show_preview_variant)
   size = local_assigns.fetch(:size, field.show_preview_size)
 %>
 
@@ -29,6 +30,7 @@ This partial renders one or more attachments
                    field: field,
                    attachment: attachment,
                    removable: removable,
+                   variant: variant,
                    size: size
                } %>
   </div>

--- a/app/views/fields/active_storage/_preview.html.erb
+++ b/app/views/fields/active_storage/_preview.html.erb
@@ -1,7 +1,11 @@
 <div class="as-field as-field-<%= action_name %>">
   <% if attachment.image? %>
     <% if attachment.variable? %>
-      <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
+      <% if variant.nil? %>
+        <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
+      <% else %>
+        <%= image_tag(attachment.variant(variant)) %>
+      <% end %>
     <% else %>
       <%= image_tag(field.url(attachment)) %>
     <% end %>

--- a/app/views/fields/active_storage/_preview.html.erb
+++ b/app/views/fields/active_storage/_preview.html.erb
@@ -1,11 +1,4 @@
-<style type="text/css" nonce="<%= content_security_policy_nonce %>">
-  #as-field-<%= attachment.id %> {
-    width: <%=size[0]/2%>px; 
-    height: auto; 
-    overflow: hidden;
-  }
-</style>
-<div id="as-field-<%= attachment.id %>">
+<div class="as-field as-field-<%= action_name %>">
   <% if attachment.image? %>
     <% if attachment.variable? %>
       <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
@@ -13,13 +6,6 @@
       <%= image_tag(field.url(attachment)) %>
     <% end %>
   <% elsif attachment.video? %>
-    <style type="text/css" nonce="<%= content_security_policy_nonce %>">
-      #as-field-video-<%= attachment.id %> {
-        object-fit: contain; 
-        width: 100%; 
-        height: 100%;
-      }
-    </style>
     <% if attachment.previewable? %>
       <%= video_tag(field.url(attachment),
                     poster: field.preview(attachment, resize_to_limit: size),
@@ -27,7 +13,7 @@
                     autobuffer: true,
                     id: "as-field-video-#{attachment.id}") %>
     <% else %>
-      <%= video_tag(field.url(attachment), controls: true, autobuffer: true, id: "as-field-video-#{attachment.id}") %>
+      <%= video_tag(field.url(attachment), controls: true, autobuffer: true, class: "as-field-video") %>
     <% end %>
   <% elsif attachment.audio? %>
     <%= audio_tag(field.url(attachment), autoplay: false, controls: true) %>

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -5,6 +5,7 @@ module Administrate
   module Field
     class ActiveStorage < Administrate::Field::Base
       class Engine < ::Rails::Engine
+        Administrate::Engine.add_stylesheet "administrate-field-active_storage/application"
       end
 
       def index_display_preview?

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -16,6 +16,10 @@ module Administrate
         options.fetch(:index_preview_size, [150, 150])
       end
 
+      def index_preview_variant
+        options.fetch(:index_preview_variant, nil)
+      end
+
       def index_display_count?
         options.fetch(:index_display_count) { attached? && attachments.count != 1 }
       end
@@ -26,6 +30,10 @@ module Administrate
 
       def show_preview_size
         options.fetch(:show_preview_size, [800, 800])
+      end
+
+      def show_preview_variant
+        options.fetch(:show_preview_variant, nil)
       end
 
       def many?


### PR DESCRIPTION
Add ability to use new (Rails 7) named variants for previewing images

To make this feasible inline CSS needed to go as well

It might be necessary to add to `app/assets/config/manifest.js`:
```
 //= link administrate-field-active_storage/application.css' in 'app/assets/config/manifest.js
```

Fixes #90 