### PR TITLE
Remove references to removable

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -16,9 +16,6 @@ controlled via a boolean local variable.
   A wrapper around the image url pulled from the database.
 - `attachment`:
   Reference to the file
-- `removable`:
-  A boolean used to control the display of a `Remove` link which
-  is used to destroy a single attachment.  Defaults to `false`
 - `size`:
   [x, y]
   Maximum size of the ActiveStorage preview.

--- a/app/views/fields/active_storage/_items.html.erb
+++ b/app/views/fields/active_storage/_items.html.erb
@@ -8,9 +8,6 @@ This partial renders one or more attachments
 - `field`:
   An instance of [Administrate::Field::Image].
   A wrapper around the image url pulled from the database.
-- `removable`:
-  A boolean used to control the display of a `Remove` link which
-  is used to destroy a single attachment.  Defaults to `false`
 - `size`:
   [x, y]
   Maximum size of the ActiveStorage preview.
@@ -18,7 +15,6 @@ This partial renders one or more attachments
 %>
 
 <%
-  removable = local_assigns.fetch(:removable, false)
   variant = local_assigns.fetch(:variant, field.show_preview_variant)
   size = local_assigns.fetch(:size, field.show_preview_size)
 %>
@@ -29,7 +25,6 @@ This partial renders one or more attachments
                locals: {
                    field: field,
                    attachment: attachment,
-                   removable: removable,
                    variant: variant,
                    size: size
                } %>


### PR DESCRIPTION
There is some documentation for passing
a removable boolean, but there is no
way to pass this boolean through the
Administrate dashboard setup. It looks
like the Remove feature was implemented
through the `destroy_url` option instead.
This removes all references to the
`removable` boolean.