### PR TITLE
Add an ability to display original images

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ It might be necessary to add to app/assets/config/manifest.js:
 ```
 When set, this takes precedence over `index_preview_size` and `show_preview_size`.
 
+Setting this to `false` displays original images instead of variants.
+
+Defaults to `nil`.
+
 ### index_display_count
 
 Displays the number of attachments in the `index` action.

--- a/app/views/fields/active_storage/_preview.html.erb
+++ b/app/views/fields/active_storage/_preview.html.erb
@@ -3,6 +3,8 @@
     <% if attachment.variable? %>
       <% if variant.nil? %>
         <%= image_tag(field.variant(attachment, resize_to_limit: size)) %>
+      <% elsif variant == false %>
+        <%= image_tag(field.url(attachment)) %>
       <% else %>
         <%= image_tag(attachment.variant(variant)) %>
       <% end %>

--- a/contribute.md
+++ b/contribute.md
@@ -15,3 +15,4 @@
 - David Ma [@taikon](https://github.com/taikon)
 - Dmitry Davydov [@haukot](https://github.com/haukot)
 - Jeanine Soterwood [@littleforest](https://github.com/littleforest)
+- Shouichi Kamiya [@shouichi](https://github.com/shouichi)


### PR DESCRIPTION
The current implementation always displays a variant if an image is variable regardless of setting `show_preview_variant` to `nil`.

```
Field::ActiveStorage.with_options(show_preview_variant: nil)
```

This change allows us to show the original image by passing `false`.

```
Field::ActiveStorage.with_options(show_preview_variant: false)
```

Though the behavioral difference between `nil` and `false` is subtle, it somewhat aligns with the Action View's `layout` method.

> https://api.rubyonrails.org/classes/ActionView/Layouts/ClassMethods.html#method-i-layout
> - false: There is no layout
> - nil: Force default layout behavior with inheritance