### PR TITLE
Add index_preview_only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ in the `index` action.
 
 Defaults to `true`.
 
+### index_preview_only
+
+If true, will show only the preview in the `index` action, and not the filename or destroy link (if set).
+
 ### index_preview_size and show_preview_size
 
 Indicate the size of the image preview for the `index` and `show` actions, respectively.

--- a/app/views/fields/active_storage/_index.html.erb
+++ b/app/views/fields/active_storage/_index.html.erb
@@ -22,7 +22,8 @@ By default, the attribute is rendered as an image tag.
                  locals: {
                      field: field,
                      variant: field.index_preview_variant,
-                     size: field.index_preview_size
+                     size: field.index_preview_size,
+                     preview_only: field.index_preview_only?
                  } %>
     <% else %>
       <%= render partial: 'fields/active_storage/item',
@@ -30,7 +31,8 @@ By default, the attribute is rendered as an image tag.
                      field: field,
                      attachment: field.data,
                      variant: field.index_preview_variant,
-                     size: field.index_preview_size
+                     size: field.index_preview_size,
+                     preview_only: field.index_preview_only?
                  } %>
     <% end %>
   <% end %>

--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -19,13 +19,17 @@ controlled via a boolean local variable.
 - `size`:
   [x, y]
   Maximum size of the ActiveStorage preview.
+- `preview_only`:
+  If true, show only the previous and not the name or destroy link
 %>
+<% preview_only = local_assigns.fetch(:preview_only, false) %>
 <% if field.show_display_preview? && attachment.persisted? %>
   <div>
     <%= render partial: 'fields/active_storage/preview', locals: local_assigns %>
   </div>
 <% end %>
 
+<% unless preview_only %>
 <% if attachment.persisted? %>
   <div>
     <%= link_to attachment.filename, field.blob_url(attachment), title: attachment.filename %>
@@ -39,4 +43,5 @@ controlled via a boolean local variable.
                 destroy_url, method: :delete, class: 'remove-attachment-link', data: { confirm: t("administrate.actions.confirm") } %>
   </div>
   <hr>
+<% end %>
 <% end %>

--- a/app/views/fields/active_storage/_items.html.erb
+++ b/app/views/fields/active_storage/_items.html.erb
@@ -17,6 +17,7 @@ This partial renders one or more attachments
 <%
   variant = local_assigns.fetch(:variant, field.show_preview_variant)
   size = local_assigns.fetch(:size, field.show_preview_size)
+  preview_only = local_assigns.fetch(:preview_only, false)
 %>
 
 <% field.attachments.each do |attachment| %>
@@ -26,7 +27,8 @@ This partial renders one or more attachments
                    field: field,
                    attachment: attachment,
                    variant: variant,
-                   size: size
+                   size: size,
+                   preview_only: preview_only
                } %>
   </div>
 <% end %>

--- a/lib/administrate/field/active_storage.rb
+++ b/lib/administrate/field/active_storage.rb
@@ -20,6 +20,10 @@ module Administrate
         options.fetch(:index_preview_variant, nil)
       end
 
+      def index_preview_only?
+        options.fetch(:index_preview_only, false)
+      end
+
       def index_display_count?
         options.fetch(:index_display_count) { attached? && attachments.count != 1 }
       end


### PR DESCRIPTION
Thanks for this amazing gem!

This PR adds a new option called `index_preview_only`. If set to true, it will suppress the rendering of the filename and destroy link for previews on index pages. I figured I'm not the only one who would benefit from the option to have "just the image".

Let me know if I've broken any conventions or you need anything updating.