### PR TITLE
Add support for Turbo vs UJS in remove link

### DIFF
--- a/app/views/fields/active_storage/_item.html.erb
+++ b/app/views/fields/active_storage/_item.html.erb
@@ -41,7 +41,7 @@ controlled via a boolean local variable.
   <% destroy_url = field.destroy_url.call(namespace, field.data.record, attachment) %>
   <div>
     <%= link_to I18n.t("administrate.fields.active_storage.remove", default: 'Remove'),
-                destroy_url, method: :delete, class: 'remove-attachment-link', data: { confirm: t("administrate.actions.confirm") } %>
+                destroy_url, method: :delete, class: 'remove-attachment-link', data: { confirm: t("administrate.actions.confirm"), turbo_method: :delete, turbo_confirm: t("administrate.actions.confirm") } %>
   </div>
   <hr>
 <% end %>


### PR DESCRIPTION
This takes the same approach as in [this `administrate` PR][1] by adding the `data-turbo-method` and `data-turbo-confirm` attributes supported by Hotwire Turbo (see the docs for ["Performing visits with a different method"][2] and ["Requiring confirmation for a visit"][3]) to the link for removing an attachment.

The existing `method` option and `data-confirm` attribute are left in place to avoid breaking [the behaviour under UJS][4] which was deprecated in Rails v7 and removed in Rails v7.2.

As the `administrate` PR says, ideally the `link_to` would be replaced by `button_to`. However, in the interests of making the change as small as possible and retaining consistency with `administrate` itself, it seems OK to keep the `link_to` in place.

[1]: https://github.com/thoughtbot/administrate/pull/2448
[2]: https://turbo.hotwired.dev/handbook/drive#performing-visits-with-a-different-method
[3]: https://turbo.hotwired.dev/handbook/drive#requiring-confirmation-for-a-visit
[4]: https://api.rubyonrails.org/v7.0/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to-label-Deprecated-3A+Rails+UJS+Attributes